### PR TITLE
Quick fix for issue #71: remove '/usr/local/bin' from managed folders

### DIFF
--- a/manifests/minimize_access.pp
+++ b/manifests/minimize_access.pp
@@ -18,7 +18,6 @@ class os_hardening::minimize_access (
   # from which folders to remove public access
   $folders = [
     '/usr/local/sbin',
-    '/usr/local/bin',
     '/usr/sbin',
     '/usr/bin',
     '/sbin',


### PR DESCRIPTION
(duplicate declaration in PE v2017.2.1 puppet_enterprise/manifests/symlinks.pp:31)