### PR TITLE
DevSec Linux Baseline os-05: login.defs should be readable by group and

### DIFF
--- a/manifests/login_defs.pp
+++ b/manifests/login_defs.pp
@@ -29,6 +29,6 @@ class os_hardening::login_defs (
       content => template( 'os_hardening/login.defs.erb' ),
       owner   => 'root',
       group   => 'root',
-      mode    => '0400',
+      mode    => '0444',
   }
 }


### PR DESCRIPTION
other